### PR TITLE
Fix rss parser import

### DIFF
--- a/backend/parsers/rss_parser.py
+++ b/backend/parsers/rss_parser.py
@@ -1,7 +1,7 @@
 
 import requests
 import xml.etree.ElementTree as ET
-from config.config import RSS_FEED_URL
+from backend.config.config import RSS_FEED_URL
 
 
 


### PR DESCRIPTION
## Summary
- correct import path for RSS_FEED_URL in rss_parser

## Testing
- `python3 -m py_compile backend/parsers/rss_parser.py`

------
https://chatgpt.com/codex/tasks/task_e_6841b1d1c2888326b6c85c78a219a79b