### PR TITLE
Add missing bunker_radio script

### DIFF
--- a/bunker_radio.py
+++ b/bunker_radio.py
@@ -1,0 +1,18 @@
+import asyncio
+from backend.dependencies import register_dependencies
+from backend.core.fallout_news_logic import run_bunker_sequence
+
+container = register_dependencies()
+
+def job():
+    headlines, response = asyncio.run(run_bunker_sequence(container))
+    telegram = container["telegram"]
+    elevenlabs = container["elevenlabs"]
+    telegram.send_message(response)
+    audio_file = elevenlabs.generate_audio(response)
+    if audio_file:
+        telegram.send_audio(audio_file)
+
+if __name__ == "__main__":
+    print("Fallout Radio: Bunker-FM launched!")
+    job()


### PR DESCRIPTION
## Summary
- add `bunker_radio.py` missing from README instructions

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `bash tester.sh` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841b1e1ac60832684b3d9322dedf3a0