### PR TITLE
Gracefully handle missing API credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,12 @@ You can install the required packages using:
 Create a `.env` file in the root directory of the project and include the following variables:
 
     GEMINI_API_KEY=your_google_gemini_api_key
-    ELEVENLABS_API_KEY=your_elevenlabs_api_key
+    ELEVENLABS_API_KEY=your_elevenlabs_api_key (optional)
     VOICE_ID=your_elevenlabs_voice_id (optional, default is '2EiwWnXFnvU5JabPnv8n')
-    TELEGRAM_BOT_TOKEN=your_telegram_bot_token
-    TELEGRAM_CHAT_ID=your_telegram_chat_id
+    TELEGRAM_BOT_TOKEN=your_telegram_bot_token (optional)
+    TELEGRAM_CHAT_ID=your_telegram_chat_id (optional)
+
+You can copy `backend/.env.example` and fill in the values. If Telegram or ElevenLabs credentials are omitted, the script will skip sending messages and audio.
 
 ## How to Run
 

--- a/backend/clients/el_labs_client.py
+++ b/backend/clients/el_labs_client.py
@@ -7,6 +7,9 @@ class ElevenLabsClient:
         self.voice_id = voice_id
 
     def generate_audio(self, text, filename='bunker_audio.mp3'):
+        if not self.api_key or not self.voice_id:
+            print("ElevenLabs credentials not provided, skipping audio generation")
+            return None
         url = f"https://api.elevenlabs.io/v1/text-to-speech/{self.voice_id}"
         headers = {
             "xi-api-key": self.api_key,

--- a/backend/clients/gemini_client.py
+++ b/backend/clients/gemini_client.py
@@ -2,6 +2,10 @@ import requests
 from backend.config.config import GEMINI_API_KEY
 
 def get_gemini_response(prompt):
+    if not GEMINI_API_KEY:
+        print("Gemini API key not provided, skipping API call")
+        return "No Gemini API key provided."
+
     url = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key={GEMINI_API_KEY}"
     headers = {"Content-Type": "application/json"}
     data = {"contents": [{"parts": [{"text": prompt}]}]}

--- a/backend/clients/telegram_client.py
+++ b/backend/clients/telegram_client.py
@@ -7,6 +7,9 @@ class TelegramClient:
         self.chat_id = chat_id
 
     def send_message(self, text):
+        if not self.token or not self.chat_id:
+            print("Telegram credentials not provided, skipping send_message")
+            return
         url = f"https://api.telegram.org/bot{self.token}/sendMessage"
         payload = {'chat_id': self.chat_id, 'text': text}
         try:
@@ -16,6 +19,9 @@ class TelegramClient:
             print(f"Error sending message to Telegram: {e}")
 
     def send_audio(self, audio_path):
+        if not self.token or not self.chat_id:
+            print("Telegram credentials not provided, skipping send_audio")
+            return
         url = f"https://api.telegram.org/bot{self.token}/sendAudio"
         try:
             with open(audio_path, 'rb') as audio_file:


### PR DESCRIPTION
## Summary
- allow running without Telegram or ElevenLabs credentials
- skip Gemini API calls when key is not configured
- document that external service credentials are optional

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b57e35308326845f490de7dc4041