### PR TITLE
Fix API endpoints and font format in test page

### DIFF
--- a/frontend/test.html
+++ b/frontend/test.html
@@ -30,7 +30,7 @@
       @font-face {
         font-family: "DepartureMono Nerd Font";
         src: url("./assets/fonts/DepartureMonoNerdFont-Regular.otf")
-          format("truetype");
+          format("opentype");
         font-weight: normal;
         font-style: normal;
       }
@@ -54,7 +54,7 @@
         output.textContent = "Contacting bunker...";
 
         try {
-          const response = await fetch("http://localhost:5001/bunker");
+          const response = await fetch("/bunker");
           if (!response.ok) throw new Error(`Server error: ${response.status}`);
 
           const data = await response.json();
@@ -70,7 +70,7 @@
         output.textContent = "Requesting audio transmission...";
 
         try {
-          const response = await fetch("http://localhost:5001/bunker/audio");
+          const response = await fetch("/bunker/audio");
           if (!response.ok) throw new Error(`Server error: ${response.status}`);
 
           const blob = await response.blob();


### PR DESCRIPTION
## Summary
- make font-face format match the otf file type
- request bunker endpoints using relative paths so the active port works

## Testing
- `python3 --version`


------
https://chatgpt.com/codex/tasks/task_e_6841c81980648326b811f2467f111a36