### PR TITLE
Fix CORS access for test page

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,17 +1,18 @@
 from flask import Flask, jsonify
 from flask import send_file
-from flask_cors import CORS
+from flask_cors import CORS, cross_origin
 import asyncio
 from backend.dependencies import register_dependencies
 from backend.core.fallout_news_logic import run_bunker_sequence
 
 app = Flask(__name__)
 # Allow all origins for development purposes (consider tightening this in production)
-CORS(app)
+CORS(app, resources={r"/bunker*": {"origins": "*"}})
 
 container = register_dependencies()
 
 @app.route("/bunker", methods=["GET"])
+@cross_origin()
 def bunker_route():
     headlines, response = asyncio.run(run_bunker_sequence(container))
     return jsonify({
@@ -22,6 +23,7 @@ def bunker_route():
 
 # New route for serving audio file
 @app.route("/bunker/audio", methods=["GET"])
+@cross_origin()
 def bunker_audio():
     try:
         return send_file("output.mp3", mimetype="audio/mpeg")

--- a/frontend/test.html
+++ b/frontend/test.html
@@ -54,7 +54,7 @@
         output.textContent = "Contacting bunker...";
 
         try {
-          const response = await fetch("http://localhost:5000/bunker");
+          const response = await fetch("/bunker");
           if (!response.ok) throw new Error(`Server error: ${response.status}`);
 
           const data = await response.json();
@@ -70,7 +70,7 @@
         output.textContent = "Requesting audio transmission...";
 
         try {
-          const response = await fetch("http://localhost:5000/bunker/audio");
+          const response = await fetch("/bunker/audio");
           if (!response.ok) throw new Error(`Server error: ${response.status}`);
 
           const blob = await response.blob();


### PR DESCRIPTION
## Summary
- allow CORS for `/bunker` endpoints
- enable CORS decorator on endpoints
- use relative API paths in `test.html`

## Testing
- `python3 -m backend.core.fallout_news_logic` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6841cca42d388326a833c8b51ff9cbfc